### PR TITLE
Fixing broken internal links, a few typos in section 1.

### DIFF
--- a/_episodes/10-section1-intro.md
+++ b/_episodes/10-section1-intro.md
@@ -44,7 +44,7 @@ code style guides (such as [PEP8](https://www.python.org/dev/peps/pep-0008/) for
 code completion and refactoring.
 IDEs often integrate command line console and version control tools - we teach
 them separately in this course as this knowledge can be ported to other programming languages and command line tools
-you may use in the future (but is perfectly fine to use these integrated versions too).
+you may use in the future (but is applicable to the integrated versions too).
 
 We will use [PyCharm](https://www.jetbrains.com/pycharm/) in this course - a free, open source IDE.
 

--- a/_episodes/10-section1-intro.md
+++ b/_episodes/10-section1-intro.md
@@ -42,7 +42,7 @@ that goes beyond a single script - including a smart code editor,
 a code compiler/interpreter, a debugger, etc. It will help you write well-formatted & readable code that conforms to
 code style guides (such as [PEP8](https://www.python.org/dev/peps/pep-0008/) for Python) more efficiently by giving relevant and intelligent suggestions for
 code completion and refactoring.
-IDEs often integrates command line console and version control tools - we teach
+IDEs often integrate command line console and version control tools - we teach
 them separately in this course as this knowledge can be ported to other programming languages and command line tools
 you may use in the future (but is perfectly fine to use these integrated versions too).
 

--- a/_episodes/11-software-development.md
+++ b/_episodes/11-software-development.md
@@ -101,6 +101,7 @@ entry point in the application, and on closer inspection, we can see that the `i
 ~~~
 $ ls -l inflammation
 total 24
+-rw-r--r--  1 alex  staff   71 29 Jun 09:59 __init__.py
 -rw-r--r--  1 alex  staff  838 29 Jun 09:59 models.py
 -rw-r--r--  1 alex  staff  649 25 Jun 13:13 views.py
 ~~~
@@ -276,7 +277,7 @@ entry point into the application. The **View** and **Model** modules are contain
 in the files `view.py` and `model.py`, respectively, and are conveniently named. Data underlying the **Model** is
 contained within the directory `data` - as we have seen already it contains several files with patients’ daily inflammation information.
 
-We will revisit the software architecture and MVC topics once again in a [later episode](../../32-software-design)
+We will revisit the software architecture and MVC topics once again in a [later episode](../34-software-design/index.html)
 when we talk in more detail about software design.
 We now proceed to set up our virtual development environment and start working with the code using
 a more convenient graphical tool - IDE PyCharm.

--- a/_episodes/15-coding-conventions.md
+++ b/_episodes/15-coding-conventions.md
@@ -499,7 +499,7 @@ The docstring for a function or a module is returned when
 calling the `help` function and passing its name - for example from the interactive Python console/terminal available
 from the command line or when rendering code documentation online 
 (e.g. see [Python documentation](https://docs.python.org/3.8/library/index.html)).
-PyCharm also displays the docstring for a function/module in a little elp popup window when using tab-completion.
+PyCharm also displays the docstring for a function/module in a little help popup window when using tab-completion.
 
 ~~~
 help(fibonacci)

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ permalink: index.html  # Is the only page that doesn't follow the pattern /:path
 
 This course aims to teach a **core set** of established, intermediate-level software development skills and
 best practices for working as part of a team in a research environment using Python as an
-example programming language (see detailed [learning objectives](/index.html#learning-objectives) below).
+example programming language (see detailed [learning objectives](/index.html#learning-objectives-for-the-workshop) below).
 The core set of skills we teach is not a comprehensive set of all-encompassing skills,
 but a selective set of tried-and-tested collaborative development skills that forms a firm foundation for continuing
 on your learning journey.
@@ -45,7 +45,7 @@ currently undocumented or unstructured
  - You have learned the basics of writing software but have not
  applied that knowledge yet (or are unsure how to apply it) to your work. In this case, we suggest you revisit the course
  after you have been programming for at least 6 months
- - You are well familiar with the [learning objectives of the course](/index.html#learning-objectives) and those of individual episodes
+ - You are well familiar with the [learning objectives of the course](/index.html#learning-objectives-for-the-workshop) and those of individual episodes
  - The software you write is fully documented and well architected
 
 > ## Prerequisites


### PR DESCRIPTION
Fixing a few broken internal links (on and between pages), typos, and a slight issue with the output of `ls` not including the `__init__.py` file.

I added the `__init__.py` file to the existing example for consistency with Aleks other `ls` outputs, instead of using an 'accurate' `ls` output. I think this level of mild forgery is OK.