### PR TITLE
Replaces https url with ssl equivalent (git@) url for github clone operation

### DIFF
--- a/_episodes/11-software-development.md
+++ b/_episodes/11-software-development.md
@@ -64,7 +64,7 @@ anything you like, but it may be easier for future group exercises if everyone u
 2. Make sure you are located in your home directory in the command line with:
 > > `cd ~`
 3. From your home directory, do:
-> > `git clone https://github.com/<YOUR_GITHUB_USERNAME>/python-intermediate-inflammation`. Make sure you are cloning 
+> > `git clone git@github.com:<YOUR_GITHUB_USERNAME>/python-intermediate-inflammation`. Make sure you are cloning 
 > > your copy of the software project and not the template repo.
 4. Navigate into the cloned repository in your command line with:
 > > `cd python-intermediate-inflammation`


### PR DESCRIPTION
GitHub [no longer allows pushing to clones using https + password authentication](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/). They now require SSH using (at least 2048-bit?) RSA keys (DSA no longer accepted).

This PR probably necessitates a separate write-up about setting up a SSH keypair, and uploading the public key onto GitHub. That topic will be anyway relevant to this course, since any large scale software development shall typically require such remote accesses.