### PR TITLE
Update 43-software-release.md

### DIFF
--- a/_episodes/43-software-release.md
+++ b/_episodes/43-software-release.md
@@ -143,7 +143,7 @@ The `pyproject.toml` file has two separate lists, allowing us to distinguish bet
 
 ~~~
 $ poetry add matplotlib numpy
-$ poetry add --dev pylint
+$ poetry add --group dev pylint
 $ poetry install
 ~~~
 {: .language-bash}


### PR DESCRIPTION
running the current lines throws up a warning message  `The --dev option is deprecated, use the `--group dev` notation instead.`  I changed the code to reflect that suggestion

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
