### PR TITLE
remove hint about deleting main on Pages repositories

### DIFF
--- a/_episodes/14-collaboration-using-git.md
+++ b/_episodes/14-collaboration-using-git.md
@@ -455,8 +455,7 @@ git push origin main
 > ## All Branches Are Equal
 > In Git, all branches are equal - there is nothing special about the `main` branch. It is called
 > that by convention and is created by default, but it can also be called something else. A good example is
-> `gh-pages` branch which is the main branch for website projects hosted on GitHub (rather than `main`, which can
-> be safely deleted for such projects).
+> `gh-pages` branch which is often the source branch for website projects hosted on GitHub (rather than `main`).
 {: .callout}
 
 > ## Keeping Main Branch Stable


### PR DESCRIPTION
This removes guidance that it is safe to delete a branch called `main` from a repository used to build a GitHub Pages website. 

Especially since GitHub made it so much easier to use static site generators other than Jekyll to build websites, a lot of repositories use `main` as their default branch. These projects have GitHub Actions or similar workflows, set up to build source HTML files that can then be served via GitHub Pages. Those source files are usually found in a `gh-pages` branch (though not always - `docs` is another common name for such branches), but this certainly does not mean it would be safe to delete `main` on these projects.

As an example: since transition to the new lesson infrastructure, almost all of The Carpentries official lesson repositories use `main` as the default branch.