### PR TITLE
GitHub Actions / YAML Section Consistency

### DIFF
--- a/_episodes/23-continuous-integration-automated-testing.md
+++ b/_episodes/23-continuous-integration-automated-testing.md
@@ -143,6 +143,20 @@ first_scaled_by:
 
 So here we have a YAML array of our two mountaineers,
 each with additional keys offering more information.
+
+GitHub Actions also makes use of `|` symbol to indicate a multi-line string
+that preserves new lines. For example:
+
+~~~
+shakespeare_couplet: |
+  Good night, good night. Parting is such sweet sorrow
+  That I shall say good night till it be morrow.
+~~~
+{: .language-yaml}
+
+They key `shakespeare_couplet` would hold the full two line string,
+preserving the new line after sorrow.
+
 As we'll see shortly, GitHub Actions workflows will use all of these.
 
 ### Defining Our Workflow

--- a/_episodes/23-continuous-integration-automated-testing.md
+++ b/_episodes/23-continuous-integration-automated-testing.md
@@ -71,8 +71,8 @@ so it's worth taking a bit of time looking into this file format.
 [YAML](https://www.commonwl.org/user_guide/yaml/)
 (a recursive acronym which stands for "YAML Ain't Markup Language")
 is a language designed to be human readable.
-The three basic things you need to know about YAML to get started with GitHub Actions are
-key-value pairs, arrays, and maps.
+The four basic things you need to know about YAML to get started with GitHub Actions are
+key-value pairs, arrays, maps and multi-line strings.
 
 So firstly, YAML files are essentially made up of **key-value** pairs,
 in the form `key: value`, for example:

--- a/_episodes/23-continuous-integration-automated-testing.md
+++ b/_episodes/23-continuous-integration-automated-testing.md
@@ -71,7 +71,7 @@ so it's worth taking a bit of time looking into this file format.
 [YAML](https://www.commonwl.org/user_guide/yaml/)
 (a recursive acronym which stands for "YAML Ain't Markup Language")
 is a language designed to be human readable.
-The four basic things you need to know about YAML to get started with GitHub Actions are
+A few basic things you need to know about YAML to get started with GitHub Actions are
 key-value pairs, arrays, maps and multi-line strings.
 
 So firstly, YAML files are essentially made up of **key-value** pairs,

--- a/_episodes/23-continuous-integration-automated-testing.md
+++ b/_episodes/23-continuous-integration-automated-testing.md
@@ -94,8 +94,8 @@ like this:
 
 ~~~
 first_scaled_by:
-  - Hans Meyer
-  - Ludwig Purtscheller
+- Hans Meyer
+- Ludwig Purtscheller
 ~~~
 {: .language-yaml}
 
@@ -132,12 +132,12 @@ Let's say we want to add more detail to our list of initial ascenders:
 ~~~
 ...
 first_scaled_by:
-  - name: Hans Meyer
-    date_of_birth: 22-03-1858
-    nationality: German
-  - name: Ludwig Purtscheller
-    date_of_birth: 22-03-1858
-    nationality: Austrian
+- name: Hans Meyer
+  date_of_birth: 22-03-1858
+  nationality: German
+- name: Ludwig Purtscheller
+  date_of_birth: 22-03-1858
+  nationality: Austrian
 ~~~
 {: .language-yaml}
 


### PR DESCRIPTION
This PR makes two changes:
 * adds an explanation of using the pipe to concatenate multi line strings
 * Use a consistent array indentation between the examples explaining YAML and the example GitHub Actions

I think there is a reasonable case to simply get rid of the introduction to YAML. The structure is designed to be somewhat intuitive, and most people will be creating GitHub Actions workflows by copy-pasting snippets to get their CI to do what they want, and therefore don't need a deep understanding of the YAML syntax. 
 
This addresses #215 