### PR TITLE
Improved wording around SSH and key authn with GitHub

### DIFF
--- a/_episodes/11-software-project.md
+++ b/_episodes/11-software-project.md
@@ -61,10 +61,9 @@ and then obtain a local copy of that project (from your GitHub) on your machine.
 
 1. Make sure you have a GitHub account
    and that you have set up your **SSH key pair for authentication with GitHub**,
-   as explained in [Setup](../setup.html#secure-access-to-github-using-git-from-command-line). Note 
-   that, while it is possible to use **HTTPS** with a personal access token for authentication with 
-   GitHub, the recommended and supported authentication method to use for this course is via SSH and key 
-   pairs.
+   as explained in [Setup](../setup.html#secure-access-to-github-using-git-from-command-line).
+   Note that, while it is possible to use **HTTPS** with a personal access token for authentication with GitHub,
+   the recommended and supported authentication method to use for this course is via SSH and key pairs.
 2. Log into your GitHub account.
 3. Go to the [software project template repository](https://github.com/carpentries-incubator/python-intermediate-inflammation)
    in GitHub.

--- a/_episodes/11-software-project.md
+++ b/_episodes/11-software-project.md
@@ -60,8 +60,11 @@ from GitHub within your own GitHub account
 and then obtain a local copy of that project (from your GitHub) on your machine.
 
 1. Make sure you have a GitHub account
-   and that you have set up your SSH key pair for authentication with GitHub,
-   as explained in [Setup](../setup.html#secure-access-to-github-using-git-from-command-line).
+   and that you have set up your **SSH key pair for authentication with GitHub**,
+   as explained in [Setup](../setup.html#secure-access-to-github-using-git-from-command-line). Note 
+   that, while it is possible to use **HTTPS** with a personal access token for authentication with 
+   GitHub, the recommended and supported authentication method to use for this course is via SSH and key 
+   pairs.
 2. Log into your GitHub account.
 3. Go to the [software project template repository](https://github.com/carpentries-incubator/python-intermediate-inflammation)
    in GitHub.
@@ -99,8 +102,8 @@ and then obtain a local copy of that project (from your GitHub) on your machine.
 > > 1. Find the SSH URL of the software project repository to clone from your GitHub account.
 > > Make sure you do not clone the original template repository but rather your own copy,
 > > as you should be able to push commits to it later on.
-> > Also make sure you select the **SSH tab** and not the **HTTPS** one -
-> > you'll be able to clone with HTTPS, but not to send your changes back to GitHub!
+> > Also make sure you select the **SSH** tab and not the **HTTPS** one -
+> > for this course, SSH is the preferred way of authenticating when sending your changes back to GitHub.
 > >
 > > ![URL to clone the repository in GitHub](../fig/clone-repository.png){: .image-with-shadow width="800px" }
 > >

--- a/_episodes/14-collaboration-using-git.md
+++ b/_episodes/14-collaboration-using-git.md
@@ -280,7 +280,7 @@ when you run `git clone remote_url` command to replicate a remote repository loc
 > You should revisit the [instructions 
 > on setting up your GitHub for SSH and key pair authentication](../setup.html#secure-access-to-github-using-git-from-command-line)
 > and can fix this from the command line by
-> resetting the remote repository URL setting on your local repository:
+> changing the remote repository's HTTPS URL to its SSH equivalent:
 >
 > ~~~
 > $ git remote set-url origin git@github.com:<YOUR_GITHUB_USERNAME>/python-intermediate-inflammation.git

--- a/_episodes/14-collaboration-using-git.md
+++ b/_episodes/14-collaboration-using-git.md
@@ -276,7 +276,7 @@ when you run `git clone remote_url` command to replicate a remote repository loc
 >
 > If, at this point (i.e. the first time you try to write to a remote repository on GitHub), 
 > you get a warning/error that HTTPS access is deprecated, or a personal access token is required,
-> then you have accidentally cloned the repository using HTTPS and not SSH.
+> then you have cloned the repository using HTTPS and not SSH.
 > You should revisit the [instructions 
 > on setting up your GitHub for SSH and key pair authentication](../setup.html#secure-access-to-github-using-git-from-command-line)
 > and can fix this from the command line by

--- a/_episodes/14-collaboration-using-git.md
+++ b/_episodes/14-collaboration-using-git.md
@@ -259,41 +259,34 @@ $ git pull
 {: .language-bash}
 
 Now we've ensured our repository is synchronised with the remote one,
-we can now push our changes.
-GitHub has recently
-[strengthened authentication requirements for Git operations](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/)
-accessing GitHub from the command line over HTTPS.
-This means you cannot use passwords for authentication over HTTPS any more -
-you either need to
-[set up and use a personal access token](https://catalyst.zoho.com/help/tutorials/githubbot/generate-access-token.html)
-for additional security if you want to continue to use HTTPS,
-or switch to use private and public key pair over SSH
-before you can push remotely the changes you made locally.
-So, when you run the command below:
+we can now push our changes:
 
 ~~~
 $ git push origin main
 ~~~
 {: .language-bash}
 
-> ## Authentication Errors
->
-> If you get a warning that HTTPS access is deprecated, or a token is required,
-> then you accidentally cloned the repository using HTTPS and not SSH.
-> You can fix this from the command line by
-> resetting the remote repository URL setting on your local repo:
->
-> ~~~
-> $ git remote set-url origin git@github.com:<YOUR_GITHUB_USERNAME>/python-intermediate-inflammation.git
-> ~~~
-> {: .language-bash}
-{: .caution}
-
 In the above command,
 `origin` is an alias for the remote repository you used when cloning the project locally
 (it is called that by convention and set up automatically by Git
 when you run `git clone remote_url` command to replicate a remote repository locally);
 `main` is the name of our main (and currently only) development branch.
+
+> ## GitHub Authentication Error
+>
+> If, at this point (i.e. the first time you try to write to a remote repository on GitHub), 
+> you get a warning/error that HTTPS access is deprecated, or a personal access token is required,
+> then you have accidentally cloned the repository using HTTPS and not SSH.
+> You should revisit the [instructions 
+> on setting up your GitHub for SSH and key pair authentication](../setup.html#secure-access-to-github-using-git-from-command-line)
+> and can fix this from the command line by
+> resetting the remote repository URL setting on your local repository:
+>
+> ~~~
+> $ git remote set-url origin git@github.com:<YOUR_GITHUB_USERNAME>/python-intermediate-inflammation.git
+> ~~~
+> {: .language-bash}
+{: .callout}
 
 >## Git Remotes
 > Note that systems like Git allow us to synchronise work between

--- a/_episodes/14-collaboration-using-git.md
+++ b/_episodes/14-collaboration-using-git.md
@@ -272,7 +272,7 @@ In the above command,
 when you run `git clone remote_url` command to replicate a remote repository locally);
 `main` is the name of our main (and currently only) development branch.
 
-> ## GitHub Authentication Error
+> ## GitHub Authentication/Authorisation Error
 >
 > If, at this point (i.e. the first time you try to write to a remote repository on GitHub), 
 > you get a warning/error that HTTPS access is deprecated, or a personal access token is required,

--- a/fig/git-feature-branch.svg
+++ b/fig/git-feature-branch.svg
@@ -3,7 +3,7 @@
    viewBox="0 0 831.49607 415.74803"
    id="svg3502"
    version="1.1"
-   inkscape:version="1.1 (c4e8f9e, 2021-05-24)"
+   inkscape:version="1.2.2 (b0a84865, 2022-12-01)"
    sodipodi:docname="git-feature-branch.svg"
    width="220mm"
    height="110mm"
@@ -37,14 +37,14 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="2182"
-     inkscape:window-height="1068"
+     inkscape:window-height="1040"
      id="namedview3608"
      showgrid="false"
      inkscape:zoom="1.3100902"
-     inkscape:cx="546.1456"
-     inkscape:cy="170.98059"
-     inkscape:window-x="448"
-     inkscape:window-y="163"
+     inkscape:cx="457.22043"
+     inkscape:cy="171.7439"
+     inkscape:window-x="378"
+     inkscape:window-y="135"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg3502"
      inkscape:pagecheckerboard="0"
@@ -58,7 +58,9 @@
      inkscape:snap-global="true"
      inkscape:object-nodes="true"
      inkscape:snap-intersection-paths="false"
-     inkscape:snap-bbox="true" />
+     inkscape:snap-bbox="true"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <style
      id="style3504">.st0{display:none;} .st1{display:inline;} .st2{fill:#FFFFFF;} .st3{fill:none;stroke:#9882CE;stroke-width:4;stroke-miterlimit:10;} .st4{fill:#FFFFFF;stroke:#404040;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st5{fill:#FFFFFF;stroke:#404040;stroke-width:4;stroke-miterlimit:10;} .st6{fill:#B3E3FF;stroke:#404040;stroke-width:4;stroke-miterlimit:10;} .st7{fill:#B18BE8;stroke:#404040;stroke-width:4;stroke-miterlimit:10;} .st8{fill:#FFFFFF;stroke:#404040;stroke-width:6;stroke-miterlimit:10;} .st9{fill:#B3E3FF;stroke:#404040;stroke-width:6;stroke-miterlimit:10;} .st10{fill:#404040;} .st11{fill:none;stroke:#404040;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st12{fill:#B18BE8;stroke:#404040;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st13{fill:#444444;} .st14{fill:none;stroke:#404040;stroke-width:4;stroke-miterlimit:10;} .st15{fill:#4ED1A1;stroke:#404040;stroke-width:4;stroke-miterlimit:10;} .st16{fill:none;stroke:#CCCCCC;stroke-width:7;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st17{fill:#FFFFFF;stroke:#CCCCCC;stroke-width:7;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st18{fill:none;stroke:#404040;stroke-width:7;stroke-miterlimit:10;} .st19{fill:#B3E3FF;stroke:#404040;stroke-width:7;stroke-miterlimit:10;} .st20{fill:none;stroke:#CCCCCC;stroke-width:8;stroke-linecap:round;stroke-miterlimit:10;} .st21{fill:none;stroke:#404040;stroke-width:8;stroke-linecap:round;stroke-miterlimit:10;} .st22{fill:#FFFFFF;stroke:#404040;stroke-width:4;stroke-linejoin:round;stroke-miterlimit:10;} .st23{fill:#B3E3FF;stroke:#404040;stroke-width:4;stroke-linejoin:round;stroke-miterlimit:10;} .st24{fill:none;stroke:#CCCCCC;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st25{fill:#999999;} .st26{fill:#4ED1A1;stroke:#404040;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st27{fill:#4CD3D6;stroke:#404040;stroke-width:4;stroke-linejoin:round;stroke-miterlimit:10;} .st28{fill:none;stroke:#59AFE1;stroke-width:4;stroke-miterlimit:10;} .st29{fill:#59AFE1;stroke:#404040;stroke-width:4;stroke-linejoin:round;stroke-miterlimit:10;} .st30{fill:none;stroke:#404040;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:0,30;} .st31{fill:#FFFFFF;stroke:#59AFE1;stroke-width:4;stroke-miterlimit:10;} .st32{fill:#FC8363;stroke:#404040;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st33{fill:#CCCCCC;stroke:#404040;stroke-width:4;stroke-miterlimit:10;} .st34{fill:#FFFFFF;stroke:#6693ED;stroke-width:4;stroke-miterlimit:10;} .st35{fill:none;stroke:#A97CDD;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st36{fill:none;stroke:#B3E3FF;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st37{fill:none;stroke:#4ED1A1;stroke-width:4;stroke-linecap:round;stroke-miterlimit:10;} .st38{fill:none;stroke:#4ED1A1;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st39{fill:#E24B88;stroke:#404040;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st40{fill:none;stroke:#DEEFF8;stroke-width:4;stroke-miterlimit:10;} .st41{fill:none;stroke:#CCCCCC;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;} .st42{fill:none;stroke:#CCCCCC;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0,14.3051;} .st43{fill:none;stroke:#CCCCCC;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0,14.1689;} .st44{fill:none;stroke:#CCCCCC;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0,13.9788;} .st45{fill:none;stroke:#CCCCCC;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0,14.7877;} .st46{fill:none;stroke:#CCCCCC;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0,14.9632;} .st47{fill:#B3E3FF;stroke:#404040;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st48{fill:none;stroke:#CCCCCC;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0,12.543;} .st49{fill:none;stroke:#CCCCCC;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0,13.6844;} .st50{fill:none;stroke:#CCCCCC;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0,13.7717;} .st51{fill:none;stroke:#CCCCCC;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0,13.6492;} .st52{fill:none;stroke:#CCCCCC;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0,13.907;} .st53{fill:#4CD3D6;stroke:#404040;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st54{fill:none;stroke:#CCCCCC;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0,14.9858;} .st55{fill:none;stroke:#CCCCCC;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0,14.0118;} .st56{fill:none;stroke:#CCCCCC;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0,14.1243;} .st57{fill:none;} .st58{fill:#FFFFFF;stroke:#404040;stroke-width:7;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st59{fill:#59AFE1;stroke:#404040;stroke-width:7;stroke-linejoin:round;stroke-miterlimit:10;} .st60{fill:#E24B88;stroke:#404040;stroke-width:7;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st61{fill:none;stroke:#404040;stroke-width:7;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st62{fill:none;stroke:#CCCCCC;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st63{fill:#FFFFFF;stroke:#CCCCCC;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st64{fill:#F5F5F5;} .st65{fill:#3873AE;} .st66{fill:#75706C;} .st67{fill:none;stroke:#B3E3FF;stroke-width:4;stroke-miterlimit:10;} .st68{fill:#6F6F6F;} .st69{fill:none;stroke:#6F6F6F;stroke-width:2;stroke-miterlimit:10;} .st70{fill:none;stroke:#6F6F6F;stroke-width:3;stroke-miterlimit:10;}</style>
   <path
@@ -101,7 +103,7 @@
      id="path3524" />
   <circle
      class="st15"
-     cx="437.94965"
+     cx="463.94965"
      cy="390.06229"
      r="15.8"
      id="circle3528"
@@ -115,7 +117,7 @@
      style="fill:#b3ff7f;fill-opacity:1" />
   <circle
      class="st15"
-     cx="300.54962"
+     cx="624.54962"
      cy="390.06229"
      r="15.8"
      id="circle3532"

--- a/setup.md
+++ b/setup.md
@@ -121,11 +121,15 @@ GitHub is a free, online host for Git repositories that you will use during the 
 you will need to open a free [GitHub](https://github.com/) account unless you don't already have one.
 
 ### Secure Access To GitHub Using Git From Command Line
-In order to access GitHub using Git from your machine securely, you need to set up a way of authenticating yourself 
-with GitHub through Git. The recommended way to do that for this course is to set up 
-[*SSH authentication*](https://www.ssh.com/academy/ssh/public-key-authentication) - a 
-method of authentication that is more secure than sending [*passwords over HTTPS*](https://security.stackexchange.com/questions/110415/is-it-ok-to-send-plain-text-password-over-https) and which requires a pair of keys - one public that you 
-upload to your GitHub account, and one private that remains on your machine. 
+
+In order to access GitHub using Git from your machine securely,
+you need to set up a way of authenticating yourself with GitHub through Git.
+The recommended way to do that for this course is to set up
+[*SSH authentication*](https://www.ssh.com/academy/ssh/public-key-authentication) -
+a method of authentication that is more secure than sending
+[*passwords over HTTPS*](https://security.stackexchange.com/questions/110415/is-it-ok-to-send-plain-text-password-over-https)
+and which requires a pair of keys -
+one public that you upload to your GitHub account, and one private that remains on your machine.
 
 GitHub provides full documentation and guides on how to:
 - [generate an SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent), and
@@ -133,15 +137,24 @@ GitHub provides full documentation and guides on how to:
 
 A short summary of the commands you need to perform is shown below.
 
-To generate an SSH key pair, you will need to run the `ssh-keygen` command from your command line tool/GitBash 
-and provide **your identity for the key pair** (e.g. the email address you used to register with GitHub) 
-via the `-C` parameter as shown below. Note that the `ssh-keygen` command can be run with different 
-parameters - e.g. to select a specific public key algorithm and key length; if you do not use them `ssh-keygen` will generate an [RSA](https://en.wikipedia.org/wiki/RSA_(cryptosystem)#:~:text=RSA%20involves%20a%20public%20key,by%20using%20the%20private%20key.) key pair for you by default. It will also prompt you to answer a few questions - e.g. where to save the keys on your machine and 
-a passphrase to use to protect your private key. Pressing 'Enter' on these prompts 
-will get `ssh-keygen` to use the default key location (within `.ssh` folder in your home directory) and set the passphrase to empty.
+To generate an SSH key pair, you will need to run the `ssh-keygen` command from your command line tool/GitBash
+and provide **your identity for the key pair** (e.g. the email address you used to register with GitHub)
+via the `-C` parameter as shown below.
+Note that the `ssh-keygen` command can be run with different parameters -
+e.g. to select a specific public key algorithm and key length;
+if you do not use them `ssh-keygen` will generate an
+[RSA](https://en.wikipedia.org/wiki/RSA_(cryptosystem)#:~:text=RSA%20involves%20a%20public%20key,by%20using%20the%20private%20key.)
+key pair for you by default.
+GitHub now recommends that you use a newer cryptographic standard,
+so please be sure to specify the `-t` flag as shown below.
+It will also prompt you to answer a few questions -
+e.g. where to save the keys on your machine and a passphrase to use to protect your private key.
+Pressing 'Enter' on these prompts will get `ssh-keygen` to use the default key location (within
+`.ssh` folder in your home directory)
+and set the passphrase to empty.
 
 ~~~
-$ ssh-keygen -C "your-github-email@example.com"
+$ ssh-keygen -t ed25519 -C "your-github-email@example.com"
 ~~~
 {: .language-bash}
 ~~~


### PR DESCRIPTION
Improved the wording around SSH and key authentication with GitHub.

1. Stressing more that we recommend SSH for authorised operations with GitHub (e.g. push)
2. Removed discussion around GitHub requiring personal access tokens with HTTPS (old news)
3. Fixed some awkward wording.
4. Used this as an opportunity to fix the git feature diagram to have a more correct timeline for "feature y" branch.

Fixes #243.