### PR TITLE
Remove setup.py reference in poetry episode

### DIFF
--- a/_episodes/43-software-release.md
+++ b/_episodes/43-software-release.md
@@ -150,8 +150,8 @@ Do you confirm generation? (yes/no) [yes] yes
 ~~~
 {: .output}
 
-We've called our package "inflammation" in the setup above,
-instead of "inflammation-analysis" like we did in our previous `setup.py`.
+Note that we've called our package "inflammation" in the setup above,
+instead of "inflammation-analysis".
 This is because Poetry will automatically find our code
 if the name of the distributable package matches the name of our module package.
 If we wanted our distributable package to have a different name,

--- a/_episodes/43-software-release.md
+++ b/_episodes/43-software-release.md
@@ -150,7 +150,7 @@ Do you confirm generation? (yes/no) [yes] yes
 ~~~
 {: .output}
 
-Note that we've called our package "inflammation" in the setup above,
+Note that we have called our package "inflammation" in the setup above,
 instead of "inflammation-analysis".
 This is because Poetry will automatically find our code
 if the name of the distributable package matches the name of our module package.


### PR DESCRIPTION
Fixes #268 

I found one other reference in the 'Setting up our Poetry Config` introduction, where it's explicitly mentioned as part of the packaging history, so I left that one in.
Other than that, I did not find any other prior mentions of `setup.py` in the lesson material.