### PR TITLE
Fixing Ruby version for website workflow

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.1'
           bundler-cache: true
 
       - name: Set up Python


### PR DESCRIPTION
As per @douglowe's fix: https://github.com/carpentries-incubator/python-intermediate-development-earth-sciences/pull/38 - this is needed for the lesson to build.

