### PR TITLE
change 'branch -c' to 'switch -c' for test-suite

### DIFF
--- a/_episodes/21-automatically-testing-software.md
+++ b/_episodes/21-automatically-testing-software.md
@@ -90,7 +90,7 @@ a common term we use to refer to sets of tests - that we'll use for our test wri
 
 ~~~
 $ git switch develop
-$ git branch -c test-suite
+$ git switch -c test-suite
 ~~~
 {: .language-bash}
 


### PR DESCRIPTION
Fixes #364: replacing `git branch -c test-suite` with `git switch -c test-suite`