### PR TITLE
Add instruction to merge test-suite branch in ep. 2.3

### DIFF
--- a/_episodes/23-continuous-integration-automated-testing.md
+++ b/_episodes/23-continuous-integration-automated-testing.md
@@ -421,6 +421,16 @@ which potentially saves us a lot of time waiting for testing results.
 Overall, this approach allows us to massively scale our automated testing
 across platforms we wish to test.
 
+With everything working as intended, we can merge this branch into `develop`
+and push it to GitHub:
+
+~~~
+$ git switch develop
+$ git merge test-suite
+$ git push origin develop
+~~~
+{:".language-bash}
+
 > ## Failed CI Builds
 > A CI build can fail when, e.g. a used Python package no longer supports a particular version of 
 > Python indicated in a GitHub Actions CI build matrix. In this case, the solution is either to 


### PR DESCRIPTION
Related to #365 

This PR is based on the [comment](https://github.com/carpentries-incubator/python-intermediate-development/issues/365#issuecomment-2317321441) by @douglowe:

> It looks to me like the test-suite branch isn't merged into develop at the end of the [Continuous Integration for Automated Testing](https://carpentries-incubator.github.io/python-intermediate-development/23-continuous-integration-automated-testing/index.html) episode. Perhaps the intention was to have the test-suite branch merged into develop at the end of this lesson instead?