### PR TITLE
Add explanations around installing our project locally

### DIFF
--- a/episodes/12-virtual-environments.md
+++ b/episodes/12-virtual-environments.md
@@ -494,6 +494,20 @@ Once again, we can use `pip` to install our local package:
 python3 -m pip install --editable .
 ```
 
+:::::::::::::::::::::::::::::::::::::::::  spoiler
+
+### This command fails for me
+
+If your `pip` installation is older than version 21.3, then this command will probably fail for you.
+This is because these older versions of `pip` do not support `pyproject.toml` as the package metadata.
+Given these versions of `pip` are now over 4 years old, we strongly recommend that you update `pip` if you can:
+
+```bash
+python3 -m pip install --upgrade pip
+```
+
+:::::::::::::::::::::::::::::::::::::::::
+
 This is similar syntax to above, with two important differences:
 
 1. The `--editable` or `-e` flag indicates that the package we are specifying should be an "editable" install.
@@ -501,6 +515,8 @@ This is similar syntax to above, with two important differences:
    This is very convenient when we are developing the package because we can instantly see changes when we call the code from within our virtual environment, rather than having to install the local package again to get the updates.
 2. The argument `'.'` indicates that the package we want to install is located in the current directory.
    The `pyproject.toml` file located in this directory then handles the rest.
+
+
 
 If we reissue the `pip list` command we should now see our local package with the name `python-intermediate-inflammation` in the output:
 

--- a/episodes/12-virtual-environments.md
+++ b/episodes/12-virtual-environments.md
@@ -483,6 +483,51 @@ six             1.16.0
 To uninstall a package installed in the virtual environment do: `python3 -m pip uninstall <package-name>`.
 You can also supply a list of packages to uninstall at the same time.
 
+### Installing Our Local Project as a Package Using `pip`
+
+Often when working on a Python project, the project itself will be a Python package (like `numpy` or `matplotlib` above) or at the very least it might be useful to treat it like a package.
+Said another way, it is usually the case we want a convenient way to call the Python code we are writing from another location, and making this code accessible as a package is the best way to do this.
+We will save the details of Python packaging for [a future episode](43-software-release.md), and for the meantime we can use the minimal package setup that our project already comes with, which is contained in the `pyproject.toml` file.
+Once again, we can use `pip` to install our local package:
+
+```bash
+python3 -m pip install --editable .
+```
+
+This is similar syntax to above, with two important differences:
+
+1. The `--editable` or `-e` flag indicates that the package we are specifying should be an "editable" install.
+   An "editable" install is one that allows the package in our environment to change dynamically based on source code locally.
+   This is very convenient when we are developing the package because we can instantly see changes when we call the code from within our virtual environment, rather than having to install the local package again to get the updates.
+2. The argument `'.'` indicates that the package we want to install is located in the current directory.
+   The `pyproject.toml` file located in this directory then handles the rest.
+
+If we reissue the `pip list` command we should now see our local package with the name `python-intermediate-inflammation` in the output:
+
+```output
+Package                          Version     Editable project location
+-------------------------------- ----------- ----------------------------------------------------------------------------------------------
+contourpy                        1.3.1
+cycler                           0.12.1
+exceptiongroup                   1.2.2
+fonttools                        4.56.0
+iniconfig                        2.0.0
+kiwisolver                       1.4.8
+matplotlib                       3.10.0
+numpy                            2.2.3
+packaging                        24.2
+pillow                           11.1.0
+pip                              22.0.2
+pluggy                           1.5.0
+pyparsing                        3.2.1
+pytest                           8.3.4
+python-dateutil                  2.9.0.post0
+python-intermediate-inflammation 0.0.0       /path/to/your/project/directory/python-intermediate-inflammation
+setuptools                       59.6.0
+six                              1.17.0
+tomli                            2.2.1
+```
+
 ### Exporting/Importing Virtual Environments Using `pip`
 
 You are collaborating on a project with a team so, naturally,
@@ -491,12 +536,11 @@ so they can easily 'clone' your software project with all of its dependencies
 and everyone can replicate equivalent virtual environments on their machines.
 `pip` has a handy way of exporting, saving and sharing virtual environments.
 
-To export your active environment -
-use `python3 -m pip freeze` command to produce a list of packages installed in the virtual environment.
+To export your active environment use the `python3 -m pip freeze --exclude-editable` command to produce a list of packages installed in the virtual environment.
 A common convention is to put this list in a `requirements.txt` file:
 
 ```bash
-(venv) $ python3 -m pip freeze > requirements.txt
+(venv) $ python3 -m pip freeze --exclude-editable > requirements.txt
 (venv) $ cat requirements.txt
 ```
 
@@ -518,6 +562,7 @@ The first of the above commands will create a `requirements.txt` file in your cu
 Yours may look a little different,
 depending on the version of the packages you have installed,
 as well as any differences in the packages that they themselves use.
+Also, we need to use the `--exclude-editable` command so that our local package is not included in the output, otherwise pip will try to pull from a specific commit at the time we made the editable install, which is not what we want.
 
 The `requirements.txt` file can then be committed to a version control system
 (we will see how to do this using Git in one of the following episodes)
@@ -526,10 +571,10 @@ They can then replicate your environment
 and install all the necessary packages from the project root as follows:
 
 ```bash
-(venv) $ python3 -m pip install -r requirements.txt
+(venv) $ python3 -m pip install -r requirements.txt --editable .
 ```
 
-As your project grows - you may need to update your environment for a variety of reasons.
+As your project grows you may need to update your environment for a variety of reasons.
 For example, one of your project's dependencies has just released a new version
 (dependency version number update),
 you need an additional package for data analysis (adding a new dependency)
@@ -604,7 +649,7 @@ to customize the command line.
 - Use `venv` to create and manage Python virtual environments.
 - Use `pip` to install and manage Python external (third-party) libraries.
 - `pip` allows you to declare all dependencies for a project in a separate file (by convention called `requirements.txt`) which can be shared with collaborators/users and used to replicate a virtual environment.
-- Use `python3 -m pip freeze > requirements.txt` to take snapshot of your project's dependencies.
+- Use `python3 -m pip freeze --exclude-editable > requirements.txt` to take snapshot of your project's dependencies.
 - Use `python3 -m pip install -r requirements.txt` to replicate someone else's virtual environment on your machine from the `requirements.txt` file.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/13-ides.md
+++ b/episodes/13-ides.md
@@ -203,7 +203,7 @@ you may remember that we can get the list of packages in the current virtual env
 using `pip`:
 
 ```bash
-(venv) $ python3 -m pip list
+(venv) $ python3 -m pip list --exclude-editable
 ```
 
 ```output
@@ -231,7 +231,7 @@ if we want to see only the list of packages that we installed,
 we can use the `python3 -m pip freeze` command instead:
 
 ```bash
-(venv) $ python3 -m pip freeze
+(venv) $ python3 -m pip freeze --exclude-editable
 ```
 
 ```output
@@ -250,13 +250,13 @@ six==1.16.0
 
 We see the `pip` package in `python3 -m pip list` but not in `python3 -m pip freeze` 
 as we did not install it using `pip`.
-Remember that we use `python3 -m pip freeze` to update our `requirements.txt` file,
+Remember that we use `python3 -m pip freeze --exclude-editable` to update our `requirements.txt` file,
 to keep a list of the packages our virtual environment includes.
 Python will not do this automatically;
 we have to manually update the file when our requirements change using:
 
 ```bash
-python3 -m pip freeze > requirements.txt
+python3 -m pip freeze --exclude-editable > requirements.txt
 ```
 
 If we want, we can also see the list of packages directly in the following subdirectory of `venv`:
@@ -399,7 +399,7 @@ six==1.16.0
 `pytest` is missing from `requirements.txt`. To add it, we need to update the file by repeating the command:
 
 ```bash
-(venv) $ python3 -m pip freeze > requirements.txt
+(venv) $ python3 -m pip freeze --exclude-editable > requirements.txt
 ```
 
 `pytest` is now present in `requirements.txt`:

--- a/episodes/16-verifying-code-style-linters.md
+++ b/episodes/16-verifying-code-style-linters.md
@@ -44,7 +44,7 @@ $ python3 -m pip install pylint
 We should also update our `requirements.txt` with this new addition:
 
 ```bash
-$ python3 -m pip freeze > requirements.txt
+$ python3 -m pip freeze --exclude-editable > requirements.txt
 ```
 
 Pylint is a command-line tool that can help our code in many ways:

--- a/episodes/21-automatically-testing-software.md
+++ b/episodes/21-automatically-testing-software.md
@@ -614,7 +614,7 @@ Since we have installed `pytest` to our environment,
 we should also regenerate our `requirements.txt`:
 
 ```bash
-$ python3 -m pip freeze > requirements.txt
+$ python3 -m pip freeze --exclude-editable > requirements.txt
 ```
 
 Finally, let us commit our new `test_models.py` file,

--- a/episodes/22-scaling-up-unit-testing.md
+++ b/episodes/22-scaling-up-unit-testing.md
@@ -213,7 +213,7 @@ Again, we should also update our `requirements.txt` file with our latest package
 which now also includes `pytest-cov`, and commit it:
 
 ```bash
-$ python3 -m pip freeze > requirements.txt
+$ python3 -m pip freeze --exclude-editable > requirements.txt
 $ cat requirements.txt
 ```
 

--- a/episodes/23-continuous-integration-automated-testing.md
+++ b/episodes/23-continuous-integration-automated-testing.md
@@ -200,7 +200,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install -r requirements.txt
+        python3 -m pip install -r requirements.txt .
 
     - name: Test with PyTest
       run: |
@@ -244,7 +244,7 @@ Each of these steps are:
   In order to locally install our `inflammation` package
   it is good practice to upgrade the version of pip that is present first,
   then we use pip to install our package dependencies.
-  Once installed, we can use `python3 -m pip install -e .` as before to install our own package.
+  Notice that it is fine to omit the `--editable` flag in this case because the source code will be static and therefore we don't need this to be an "editable" install like when we are developing locally.
   We use `run` here to run theses commands in the CI shell environment
 - **Test with PyTest:** lastly, we run `python3 -m pytest`,
   with the same arguments we used manually before
@@ -383,10 +383,10 @@ jobs:
     - name: Install Python dependencies
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install -r requirements.txt
+        python3 -m pip install -r requirements.txt .
     - name: Test with PyTest
       run: |
-        python3 -m pytest --cov=catchment.models tests/test_models.py
+        python3 -m pytest --cov=inflammation.models tests/test_models.py
 ```
 
 The `{{ }}` are used

--- a/slides/section_1_setting_up_environment.md
+++ b/slides/section_1_setting_up_environment.md
@@ -341,9 +341,9 @@ Read through and follow along until the end of the episode page.
 rm -r venv/
 python3 -m venv venv
 source venv/bin/activate
-pip install <your_dependencies> 
+pip install --editable . <list_your_dependencies>
 # or
-pip install -r requirements.txt  # great reason to have this file
+pip install -r requirements.txt --editable .  # great reason to have this file
 
 ```
 <!-- #endregion -->

--- a/slides/section_1_setting_up_environment.md
+++ b/slides/section_1_setting_up_environment.md
@@ -341,9 +341,9 @@ Read through and follow along until the end of the episode page.
 rm -r venv/
 python3 -m venv venv
 source venv/bin/activate
-pip install --editable . <list_your_dependencies>
+pip install <list_your_dependencies>
 # or
-pip install -r requirements.txt --editable .  # great reason to have this file
+pip install -r requirements.txt # great reason to have this file
 
 ```
 <!-- #endregion -->

--- a/slides/section_4_collaborative_soft_dev.md
+++ b/slides/section_4_collaborative_soft_dev.md
@@ -305,7 +305,7 @@ poetry --version  # check we have access to the poetry executable
   git clone <our_repo>
   python -m venv venv
   . venv/bin/activate
-  pip install -r requirements.txt
+  pip install -r requirements.txt --editable .
   python inflammation-analysis.py
   ...
   ```


### PR DESCRIPTION
As explained in #278, it is often a point of friction that learners don't have the local project installed in their virtual environment. Even though a lot of this can be alleviated by using `python -m <command>`, there are still deficits in that this command *must* be executed from the top level of the project where the `inflammation/` source directory is located.

As I also mention in that issue, it is standard practice to locally install the package you are working on and do so with an editable install. At the level of this course, I think this is an essential practice to impart.

Closes #278 

Please also see https://github.com/carpentries-incubator/python-intermediate-inflammation/pull/41 for the relevant change needed for the learner repo.