### PR TITLE
use iso-formated date in example

### DIFF
--- a/episodes/23-continuous-integration-automated-testing.md
+++ b/episodes/23-continuous-integration-automated-testing.md
@@ -128,10 +128,10 @@ Let us say we want to add more detail to our list of initial ascenders:
 ...
 first_scaled_by:
 - name: Hans Meyer
-  date_of_birth: 22-03-1858
+  date_of_birth: 1858-03-22
   nationality: German
 - name: Ludwig Purtscheller
-  date_of_birth: 22-03-1858
+  date_of_birth: 1858-03-22
   nationality: Austrian
 ```
 


### PR DESCRIPTION
I don't see a reason to use the date format DD-MM-YYYY in the example. Thus: use the standard iso YYYY-MM-DD format instead to show good practice in action.