### PR TITLE
Switch code review PR target to be develop branch rather than main

### DIFF
--- a/episodes/41-code-review.md
+++ b/episodes/41-code-review.md
@@ -235,7 +235,7 @@ on your repository (acting as a code author).
 2. Navigate to the pull requests tab.
 3. Create a new pull request by clicking the green `New pull request` button.
   ![](fig/github-pull-request-tab.png){alt='GitHub pull requests tab' .image-with-shadow width="900px"}
-4. Select the base and the compare branch - `main` and `feature-std-dev`, respectively.
+4. Select the base and the compare branch: `develop` and `feature-std-dev`, respectively.
   Recall that the base branch is where you want your changes to be merged
   and the compare branch contains the changes.
 5. Click `Create pull request` button to open the request.


### PR DESCRIPTION
In the "Raising a Pull Request" section of Episode 4.1, the target branch for the PR is set to be `main`. If we are following "gitflow" like in the rest of the lesson, this should be `develop`. This has directly caused confusion in our runs of the course and I don't think it should cause any issues, although there might be some merge conflicts because the `develop` branch has had quite a bit done to it by this point, and the `feature-std-dev` branch is quite far behind.

I will report back how it goes, but if someone is able to resolve this more immediately, that would be appreciated.

Resolves #458 