### PR TITLE
Correct inconsistent function name usage in code refactoring exercise

### DIFF
--- a/episodes/34-code-refactoring.md
+++ b/episodes/34-code-refactoring.md
@@ -282,7 +282,7 @@ i.e. their tests are:
 ::: challenge
 ## Exercise: Testing a Pure Function
 
-Add tests for `compute_standard_deviation_by_data()` that check for situations
+Add tests for `compute_standard_deviation_by_day()` that check for situations
 when there is only one file with multiple rows,
 multiple files with one row, and any other cases you can think of that should be tested.
 
@@ -299,9 +299,9 @@ with more inputs and expected outputs:
 ],
 ids=['Two patients in same file', 'Two patients in different files', 'Two identical patients in two different files'])
 def test_compute_standard_deviation_by_day(data, expected_output):
-    from inflammation.compute_data import compute_standard_deviation_by_data
+    from inflammation.compute_data import compute_standard_deviation_by_day
 
-    result = compute_standard_deviation_by_data(data)
+    result = compute_standard_deviation_by_day(data)
     npt.assert_array_almost_equal(result, expected_output)
 ```
 


### PR DESCRIPTION
Fixes #466

Changes usages of `compute_standard_deviation_by_data` for function name to `compute_standard_deviation_by_day` to be consistent with earlier exercise. Between `compute_standard_deviation_by_data` and `compute_standard_deviation_by_day` the latter seemed the more descriptive of what the function computes and so the better to standardise on.