### PR TITLE
Fix learning objectives for the workshop

### DIFF
--- a/index.md
+++ b/index.md
@@ -72,7 +72,7 @@ This course is not for you if:
   and those of individual episodes
 - The software you write is fully documented and well architected
 
-## Learning Objectives for the Workshop
+## Course Learning Objectives
 
 After going through this course, participants will be able to:
 


### PR DESCRIPTION
The learning objective section in the "summary and setup" episode was not rendered. I think the "objectives" block would also require the "questions" block in order to be rendered as an episode overview - but from the context this seems to better fit a regular subsection in the episode?