### PR TITLE
Remove Latin phrases from content

### DIFF
--- a/episodes/12-virtual-environments.md
+++ b/episodes/12-virtual-environments.md
@@ -184,7 +184,7 @@ Note that each Python distribution comes with its own version of `pip` -
 and if you have several Python versions installed you have to be extra careful to
 use the correct `pip` to manage external packages for that Python version.
 
-`venv` and `pip` are considered the *de facto* standards for virtual environment
+`venv` and `pip` are considered the effective standards for virtual environment
 and package management for Python 3.
 However, the advantages of using Anaconda and `conda` are that
 you get (most of the) packages needed for scientific code development included with the distribution.

--- a/episodes/13-ides.md
+++ b/episodes/13-ides.md
@@ -236,7 +236,7 @@ and has added these libraries effectively replicating our virtual environment in
 
 ![](fig/pycharm-installed-packages.png){alt='Packages Currently Installed in a Virtual Environment in PyCharm' .image-with-shadow width="800px"}
 
-Also note that, although the names are not the same - this is one and the same virtual environment and changes done to it in PyCharm will propagate to the command line and vice versa.
+Also note that, although the names are not the same - this is one and the same virtual environment and changes done to it in PyCharm will propagate to the command line and the other way round.
 
 
 ### VS Code

--- a/episodes/33-code-decoupling-abstractions.md
+++ b/episodes/33-code-decoupling-abstractions.md
@@ -103,7 +103,7 @@ def analyse_data(data_dir):
 ```
 
 The code is now easier to follow since we do not need to understand the data loading part
-to understand the statistical analysis part, and vice versa.
+to understand the statistical analysis part, and the other way round.
 In most cases, functions work best when they are short!
 
 

--- a/episodes/42-software-reuse.md
+++ b/episodes/42-software-reuse.md
@@ -106,7 +106,7 @@ In addition to enabling general reproducibility by others, documentation...
   such that the software's functionality can be *replicated* and re-implemented elsewhere
 - Provides a descriptive link back to the science that underlies it.
   As a reference, it makes it far easier to know how to
-  update the software as the scientific theory changes (and potentially vice versa)
+  update the software as the scientific theory changes (and potentially the other way round)
 - Importantly, it can enable others to understand the software sufficiently to
   *modify and reuse* it to do different things
 

--- a/episodes/53-improvement-through-feedback.md
+++ b/episodes/53-improvement-through-feedback.md
@@ -129,7 +129,7 @@ and use it to assign effort estimates
 As a team
 go through the issues that your partner team has registered with your software repository,
 and quickly estimate how long each issue will take to resolve in minutes.
-Do this by blind consensus first,
+Do this by blind agreement first,
 each anonymously submitting an estimate,
 and then briefly discuss your rationale and decide on a final estimate.
 Make sure these are honest estimates,


### PR DESCRIPTION
fixes #525 

This PR replaces some common Latin phrases with English equivalents. For this, episodes were searched for common latin phrases from [here](https://www.englishclub.com/vocabulary/fw-latin-phrases.php) and [here](https://www.lingualinx.com/blog/common-latin-phrases-used-in-english). 

Phrases that were found and replaced are: "de facto", "vice versa" and "consensus

Phrases that were found but not replaced: "etc.",  "per", "versus", "vs"
These were not replaced because they were considered so common that they pose no problem. However, this is still open for discussion.